### PR TITLE
feat(scraper/github): increase github rate limit with authentication

### DIFF
--- a/scraper/github/app/settings.py
+++ b/scraper/github/app/settings.py
@@ -2,3 +2,4 @@
 # All settings/parameter for the application
 
 GITHUB_API = "https://api.github.com"
+GITHUB_TOKENPATH = "./.secrets/token"

--- a/scraper/github/app/utils/github_requests.py
+++ b/scraper/github/app/utils/github_requests.py
@@ -4,8 +4,12 @@
 import requests
 import json
 
-from app.settings import GITHUB_API
+from app.settings import GITHUB_API, GITHUB_TOKENPATH
 
+def get_githubtoken():
+    with open(GITHUB_TOKENPATH, 'r') as file:
+        token = file.read().replace('\n', '')
+    return token
 
 def status_check(r):
     """
@@ -53,8 +57,8 @@ def get_users(
         query = "location:%22cameroon%22+location:%22cameroun%22&page={}".format(page)
 
         # a simple request to the api
-        r = requests.get("{}/search/users?q={}".format(GITHUB_API, query))
-
+        headers = {"Authorization": "token {}".format(get_githubtoken())}
+        r = requests.get("{}/search/users?q={}".format(GITHUB_API, query), headers=headers)
         # We check the status of the requet and return a predefined error message
         schk = status_check(r)
         if not schk[0]:
@@ -86,7 +90,9 @@ def get_user(user_name: str):
     user_name = user_name.replace("@", "") if "@" in user_name else user_name
 
     # we make a simple request to the api
-    r = requests.get("{}/users/{}".format(GITHUB_API, user_name))
+
+    headers = {"Authorization": "token {}".format(get_githubtoken())}
+    r = requests.get("{}/users/{}".format(GITHUB_API, user_name), headers=headers)
 
     # We check the status of the requet and return a predefined error message
     schk = status_check(r)


### PR DESCRIPTION
### This PR increases github search client rate limit

Previously we were limited to 10 requests per minutes to the search api and with authentication we will be able to make
30 requests per minutes that allows us to fetch more data (up to 1000) than we did. You can find more on this page describing github search rate limit https://docs.github.com/en/free-pro-team@latest/rest/reference/search#rate-limit