### PR TITLE
fix: call searchdevelopper with 21 (#157)

### DIFF
--- a/frontend/src/containers/developers.tsx
+++ b/frontend/src/containers/developers.tsx
@@ -47,7 +47,7 @@ const DeveloperPage = () => {
   const [selectedDeveloper, setSelectedDeveloper] = React.useState<GithubUser | undefined>();
 
   const { data: developersList, error, isLoading } = useQuery(
-    ["developers", { page: currentPage, count: 20, sortType: sortMethod, ...filters }],
+    ["developers", { page: currentPage, count: 21, sortType: sortMethod, ...filters }],
     searchDevelopers,
     DEFAULT_CACHE_OPTIONS,
   );


### PR DESCRIPTION
The previous PR failed to update the call parameters, which have been overriding the default value of the parameter count (21) when calling searchDevelopers. :crying_cat_face:  