### PR TITLE
fix: Added a link in the footer for OSS brand

### DIFF
--- a/frontend/src/components/layout/footer.tsx
+++ b/frontend/src/components/layout/footer.tsx
@@ -56,6 +56,11 @@ const Footer = () => {
                 </a>
               </li>
               <li>
+                <a className="txt-dark" href="https://github.com/osscameroon/Branding" rel="noreferrer" target="_blank">
+                  {formatMessage(footerMessages.brandResources)}
+                </a>
+              </li>
+              <li>
                 <NavLink to="/privacy">
                   <span>{formatMessage(footerMessages.privacy)}</span>
                 </NavLink>

--- a/frontend/src/locales/en.json
+++ b/frontend/src/locales/en.json
@@ -31,6 +31,7 @@
   "app.footer.menuTitle": "Site",
   "app.footer.developers": "Developers",
   "app.footer.projects": "Projects",
+  "app.footer.brandResources": "OSS brand resources",
   "app.footer.tweets": "Tweets",
   "app.footer.privacy": "Privacy policy",
   "app.footer.terms": "Terms of use",

--- a/frontend/src/locales/fr.json
+++ b/frontend/src/locales/fr.json
@@ -31,6 +31,7 @@
   "app.footer.menuTitle": "Site",
   "app.footer.developers": "Développeurs",
   "app.footer.projects": "Projets",
+  "app.footer.brandResources": "Charte graphique OSS",
   "app.footer.tweets": "Tweets",
   "app.footer.privacy": "Confidentialité",
   "app.footer.terms": "Conditions d'utilisation",

--- a/frontend/src/locales/messages.ts
+++ b/frontend/src/locales/messages.ts
@@ -147,6 +147,10 @@ export const footerMessages = defineMessages({
     id: "app.common.yotas",
     defaultMessage: "Shop",
   },
+  brandResources : {
+    id: "app.common.brandResources",
+    defaultMessage: "OSS brand resources",
+  },
   privacy: {
     id: "app.footer.privacy",
     defaultMessage: "Privacy policy",


### PR DESCRIPTION
Added a link in the footer for OSS Brand Resources and a french translation (Charte graphique OSS)